### PR TITLE
WIP: pickle.dumps test

### DIFF
--- a/dask/dataframe/io/tests/test_sql.py
+++ b/dask/dataframe/io/tests/test_sql.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
 import io
+import pickle
 
 import pytest
 
@@ -405,6 +406,8 @@ def test_to_sql(npartitions):
     # Verify number of partitions returned, when compute=False
     with tmp_db_uri() as uri:
         result = ddf.to_sql("test", uri, compute=False,)
+
+        pickle.dumps(result)
 
         # the first result is from the "meta" insert
         actual = len(result.compute()) - 1


### PR DESCRIPTION
(this PR forks off of dask#6038)

Add an example test calling `pickle.dumps` on a delayed `to_sql` graph; currently fails:

```
>           pickle.dumps(result)
E           AttributeError: Can't pickle local object 'sequence.<locals>._sequence'
```

`_sequence` is part of [a task-graph-linearization helper I wrote in #6038](https://github.com/dask/dask/pull/6038/files#diff-64b17ee9155433cad463c80a971a3223R1384): perhaps it's not built in an acceptable/correct way?

Strangely, such graphs execute fine using a local `Client()` (see #2), which I would assume meant they could be serialized correctly.

Pointers welcome.